### PR TITLE
add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 The chef-handler-slack gem is a Chef report mechanism that sends
 failures to a Slack channel.
 
+## Deprecated
+
+Recent Slack changes no longer accept the team specific webhook urls, so this gem does not work anymore.
+
+It is recommended to use [rackspace-cookbooks/chef-slack_handler](https://github.com/rackspace-cookbooks/chef-slack_handler) instead of this gem.
+
 ## Usage
 
 Create a new recipe, with the following contents, and add it to the runlist of your base role in Chef:


### PR DESCRIPTION
this gem no longer works, something like #3 should be merged.

i see that you have considered switching to dcm-ops/chef-slack_handler:
https://github.com/tinyspeck/chef-handler-slack/issues/1#issuecomment-63582035

but meanwhile that repo has been also obsoleted, and replaced by maintained version at
https://github.com/rackspace-cookbooks/chef-slack_handler
